### PR TITLE
Implement basic search UI with cache loading

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,5 +1,5 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from ue_configurator.indexer import index_headers
+from ue_configurator.indexer import index_headers, load_cache
 from pathlib import Path
 
 def test_index_headers(tmp_path: Path):
@@ -7,3 +7,10 @@ def test_index_headers(tmp_path: Path):
     header.write_text('IConsoleVariable::Register("r.Test", "Test desc", 0);')
     result = index_headers(tmp_path)
     assert any(r["name"] == "r.Test" for r in result)
+
+
+def test_load_cache(tmp_path: Path):
+    cache = tmp_path / "cache.json"
+    cache.write_text('[{"name": "r.Test", "description": "Test"}]')
+    data = load_cache(cache)
+    assert data[0]["name"] == "r.Test"

--- a/ue_configurator/indexer.py
+++ b/ue_configurator/indexer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import json
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, List, Dict
 
 import rich.progress
 
@@ -31,6 +31,15 @@ def index_headers(root: Path) -> list[dict[str, str]]:
 def build_cache(engine_root: Path, cache_file: Path) -> None:
     data = index_headers(engine_root)
     cache_file.write_text(json.dumps(data, indent=2))
+
+
+def load_cache(cache_file: Path) -> List[Dict[str, str]]:
+    if cache_file.exists():
+        try:
+            return json.loads(cache_file.read_text())
+        except Exception:
+            pass
+    return []
 
 
 def main() -> None:

--- a/ue_configurator/ui/details_pane.py
+++ b/ue_configurator/ui/details_pane.py
@@ -1,0 +1,22 @@
+"""DetailsPane shows full info for a selected CVar."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QTextBrowser
+
+
+class DetailsPane(QWidget):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("CVar Details")
+        self.text = QTextBrowser()
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.text)
+
+    def show_details(self, info: Dict[str, str]) -> None:
+        desc = info.get("description", "")
+        file = info.get("file", "")
+        content = f"<b>{info.get('name')}</b><br>{desc}<br><i>{file}</i>"
+        self.text.setHtml(content)

--- a/ue_configurator/ui/main_window.py
+++ b/ue_configurator/ui/main_window.py
@@ -1,0 +1,39 @@
+"""Main window combining search and details panes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import QSplitter, QMainWindow
+
+from .search_pane import SearchPane
+from .details_pane import DetailsPane
+
+
+class MainWindow(QMainWindow):
+    def __init__(self, cache_file: Path) -> None:
+        super().__init__()
+        self.setWindowTitle("UE Config Assistant")
+
+        self.search = SearchPane(cache_file)
+        self.details = DetailsPane()
+
+        self.search.table.itemSelectionChanged.connect(self.show_details)
+
+        splitter = QSplitter()
+        splitter.addWidget(self.search)
+        splitter.addWidget(self.details)
+
+        self.setCentralWidget(splitter)
+
+    def show_details(self) -> None:
+        rows = self.search.table.selectionModel().selectedRows()
+        if not rows:
+            return
+        row = rows[0].row()
+        item = {
+            "name": self.search.table.item(row, 0).text(),
+            "description": self.search.table.item(row, 1).text(),
+            "file": self.search.table.item(row, 2).text(),
+        }
+        self.details.show_details(item)

--- a/ue_configurator/ui/project_chooser.py
+++ b/ue_configurator/ui/project_chooser.py
@@ -9,8 +9,9 @@ from PySide6.QtWidgets import (
     QListWidget,
     QPushButton,
     QFileDialog,
-    QMessageBox,
 )
+
+from .main_window import MainWindow
 
 RECENT_FILE = Path.home() / ".ue5_config_assistant" / "recent.json"
 
@@ -63,5 +64,9 @@ class ProjectChooser(QWidget):
     def _select(self, path: str) -> None:
         projects = [path] + [self.recent.item(i).text() for i in range(self.recent.count()) if self.recent.item(i).text() != path]
         save_recent(projects[:10])
-        QMessageBox.information(self, "Project Selected", f"Selected project: {path}\n(Next steps not implemented)")
+
+        cache = Path.home() / ".ue5_config_assistant" / "cvar_cache.json"
+        self.main_window = MainWindow(cache)  # type: ignore[attr-defined]
+        self.main_window.show()
+        self.close()
 

--- a/ue_configurator/ui/search_pane.py
+++ b/ue_configurator/ui/search_pane.py
@@ -1,0 +1,68 @@
+"""SearchPane for browsing indexed CVars."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLineEdit,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+)
+
+from ..indexer import load_cache, build_cache
+
+
+class SearchPane(QWidget):
+    def __init__(self, cache_file: Path) -> None:
+        super().__init__()
+        self.cache_file = cache_file
+        self.setWindowTitle("UE Config Assistant - Search")
+
+        self.search_box = QLineEdit()
+        self.table = QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["Name", "Description", "File"])
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.search_box)
+        layout.addWidget(self.table)
+
+        self.search_box.textChanged.connect(self.update_filter)
+
+        self.data: List[Dict[str, str]] = []
+        self.load_data()
+        self.update_table()
+
+    def load_data(self) -> None:
+        if self.cache_file.exists():
+            self.data = load_cache(self.cache_file)
+        else:
+            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
+            engine_root = self.ask_engine_root()
+            if engine_root:
+                build_cache(Path(engine_root), self.cache_file)
+                self.data = load_cache(self.cache_file)
+
+    def ask_engine_root(self) -> str | None:
+        from PySide6.QtWidgets import QFileDialog
+
+        path = QFileDialog.getExistingDirectory(self, "Select Engine Root")
+        return path or None
+
+    def update_filter(self, text: str) -> None:
+        filtered = [d for d in self.data if text.lower() in d["name"].lower() or text.lower() in d["description"].lower()]
+        self.update_table(filtered)
+
+    def update_table(self, items: List[Dict[str, str]] | None = None) -> None:
+        items = items if items is not None else self.data
+        self.table.setRowCount(len(items))
+        for row, item in enumerate(items):
+            self.table.setItem(row, 0, QTableWidgetItem(item["name"]))
+            self.table.setItem(row, 1, QTableWidgetItem(item["description"]))
+            self.table.setItem(row, 2, QTableWidgetItem(item.get("file", "")))
+        self.table.resizeRowsToContents()


### PR DESCRIPTION
## Summary
- build simple GUI widgets for searching CVars
- open main window after selecting a project
- add cache loading helper for indexer
- expand tests for indexer

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885fedcb7a0832381bc34d5cc7260f3