### PR TITLE
Add ConfigDB and duplicate detection

### DIFF
--- a/tests/test_config_db.py
+++ b/tests/test_config_db.py
@@ -1,0 +1,28 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from ue_configurator.config_db import ConfigDB
+from pathlib import Path
+
+
+def write_ini(path: Path, content: str) -> None:
+    path.write_text(content)
+
+
+def test_duplicate_detection(tmp_path: Path):
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    ini1 = cfg / "DefaultGame.ini"
+    ini2 = cfg / "ProjectGame.ini"
+    write_ini(ini1, "[Section]\nKey=1\n")
+    write_ini(ini2, "[Section]\nKey=2\n")
+
+    db = ConfigDB()
+    db.load(cfg)
+    dups = db.find_duplicates()
+    assert ("Section", "key") in dups
+    assert len(dups[("Section", "key")]) == 2
+
+
+
+

--- a/ue_configurator/__init__.py
+++ b/ue_configurator/__init__.py
@@ -1,3 +1,5 @@
 """UE Config Assistant package."""
 
-__all__ = ["main"]
+__all__ = ["main", "ConfigDB"]
+
+from .config_db import ConfigDB

--- a/ue_configurator/config_db.py
+++ b/ue_configurator/config_db.py
@@ -1,0 +1,95 @@
+"""Config database for merging and manipulating ini files."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+from configupdater import ConfigUpdater
+
+
+class IniFile:
+    """Wrapper around ConfigUpdater preserving file path."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.updater = ConfigUpdater()
+        if path.exists():
+            self.updater.read(str(path))
+
+    def comment_option(self, section: str, option: str) -> None:
+        """Comment out an option if it exists."""
+        if self.updater.has_section(section) and self.updater[section].has_option(option):
+            self.updater[section][option].comment()
+
+    def write(self, backup_dir: Path) -> None:
+        """Write file to disk with backup."""
+        if self.path.exists():
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(self.path, backup_dir / self.path.name)
+        with self.path.open("w", encoding="utf-8") as f:
+            self.updater.write(f)
+
+
+class ConfigDB:
+    """In-memory merged view of ini files."""
+
+    PRIORITY = [
+        "Default",  # lowest
+        "Project",
+        "Platform",
+        "GameUserSettings",  # highest
+    ]
+
+    def __init__(self) -> None:
+        self.files: List[IniFile] = []
+
+    def load(self, config_dir: Path) -> None:
+        patterns = [
+            "Default*.ini",
+            "Project*.ini",
+            "Platform*.ini",
+            "GameUserSettings.ini",
+        ]
+        for pat in patterns:
+            for path in sorted(config_dir.glob(pat)):
+                self.files.append(IniFile(path))
+
+    def entries(self) -> Dict[Tuple[str, str], List[IniFile]]:
+        result: Dict[Tuple[str, str], List[IniFile]] = {}
+        for ini in self.files:
+            for sec_name in ini.updater.sections():
+                section = ini.updater[sec_name]
+                for opt_name, option in section.items():
+                    key = (sec_name, opt_name)
+                    result.setdefault(key, []).append(ini)
+        return result
+
+    def find_duplicates(self) -> Dict[Tuple[str, str], List[IniFile]]:
+        dups = {k: v for k, v in self.entries().items() if len(v) > 1}
+        return dups
+
+    def comment_lower_priority(self) -> None:
+        dups = self.find_duplicates()
+        for (section, option), files in dups.items():
+            # sort files by priority
+            files_sorted = sorted(
+                files,
+                key=lambda f: self._priority_of(f.path.name),
+            )
+            # keep highest priority (last) uncommented
+            for ini in files_sorted[:-1]:
+                ini.comment_option(section, option)
+
+    def _priority_of(self, filename: str) -> int:
+        for idx, prefix in enumerate(self.PRIORITY):
+            if filename.startswith(prefix):
+                return idx
+        return -1
+
+    def save(self, config_dir: Path) -> None:
+        backup_dir = config_dir / "Backup" / datetime.now().strftime("%Y-%m-%d-%H%M%S")
+        for ini in self.files:
+            ini.write(backup_dir)

--- a/ue_configurator/settings.py
+++ b/ue_configurator/settings.py
@@ -1,0 +1,23 @@
+"""Load and save user settings."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+SETTINGS_FILE = Path.home() / ".ue5_config_assistant" / "settings.json"
+
+
+def load_settings() -> Dict[str, Any]:
+    if SETTINGS_FILE.exists():
+        try:
+            return json.loads(SETTINGS_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def save_settings(data: Dict[str, Any]) -> None:
+    SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SETTINGS_FILE.write_text(json.dumps(data, indent=2))

--- a/ue_configurator/ui/conflict_pane.py
+++ b/ue_configurator/ui/conflict_pane.py
@@ -1,0 +1,38 @@
+"""UI pane for resolving duplicate config entries."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple, List
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QRadioButton,
+    QButtonGroup,
+)
+
+from ..config_db import ConfigDB, IniFile
+
+
+class ConflictPane(QWidget):
+    def __init__(self, db: ConfigDB) -> None:
+        super().__init__()
+        self.db = db
+        self.setWindowTitle("Resolve Duplicates")
+        self.tree = QTreeWidget()
+        self.tree.setHeaderLabels(["Section", "Key", "File"])
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.tree)
+        self.populate()
+
+    def populate(self) -> None:
+        self.tree.clear()
+        dups = self.db.find_duplicates()
+        for (section, option), files in dups.items():
+            parent = QTreeWidgetItem([section, option])
+            self.tree.addTopLevelItem(parent)
+            for ini in files:
+                QTreeWidgetItem(parent, ["", ini.path.name])
+        self.tree.expandAll()

--- a/ue_configurator/ui/main_window.py
+++ b/ue_configurator/ui/main_window.py
@@ -4,16 +4,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6.QtWidgets import QSplitter, QMainWindow
+from PySide6.QtWidgets import QSplitter, QMainWindow, QAction
+
+from ..config_db import ConfigDB
+from .conflict_pane import ConflictPane
+from .preset_pane import PresetPane
 
 from .search_pane import SearchPane
 from .details_pane import DetailsPane
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, cache_file: Path) -> None:
+    def __init__(self, cache_file: Path, project_dir: Path) -> None:
         super().__init__()
         self.setWindowTitle("UE Config Assistant")
+        self.project_dir = project_dir
+        self.db = ConfigDB()
+        config_dir = project_dir / "Config"
+        if config_dir.exists():
+            self.db.load(config_dir)
 
         self.search = SearchPane(cache_file)
         self.details = DetailsPane()
@@ -26,6 +35,14 @@ class MainWindow(QMainWindow):
 
         self.setCentralWidget(splitter)
 
+        # menu actions
+        conflict_action = QAction("Show Duplicates", self)
+        conflict_action.triggered.connect(self.show_conflicts)
+        preset_action = QAction("Presets", self)
+        preset_action.triggered.connect(self.show_presets)
+        self.menuBar().addAction(conflict_action)
+        self.menuBar().addAction(preset_action)
+
     def show_details(self) -> None:
         rows = self.search.table.selectionModel().selectedRows()
         if not rows:
@@ -37,3 +54,13 @@ class MainWindow(QMainWindow):
             "file": self.search.table.item(row, 2).text(),
         }
         self.details.show_details(item)
+
+    def show_conflicts(self) -> None:
+        self.db.comment_lower_priority()
+        pane = ConflictPane(self.db)
+        pane.show()
+
+    def show_presets(self) -> None:
+        presets = self.project_dir / "Presets"
+        pane = PresetPane(presets)
+        pane.show()

--- a/ue_configurator/ui/preset_pane.py
+++ b/ue_configurator/ui/preset_pane.py
@@ -1,0 +1,54 @@
+"""UI for importing and exporting config presets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QListWidget,
+    QPushButton,
+    QFileDialog,
+)
+
+
+class PresetPane(QWidget):
+    def __init__(self, presets_dir: Path) -> None:
+        super().__init__()
+        self.presets_dir = presets_dir
+        self.setWindowTitle("Presets")
+
+        self.list = QListWidget()
+        self.import_btn = QPushButton("Import")
+        self.export_btn = QPushButton("Export Current")
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.list)
+        layout.addWidget(self.import_btn)
+        layout.addWidget(self.export_btn)
+
+        self.import_btn.clicked.connect(self.import_preset)
+        self.export_btn.clicked.connect(self.export_preset)
+        self.load_presets()
+
+    def load_presets(self) -> None:
+        self.list.clear()
+        self.presets_dir.mkdir(parents=True, exist_ok=True)
+        for p in self.presets_dir.glob("*.ini"):
+            self.list.addItem(p.name)
+
+    def import_preset(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(self, "Select preset", str(self.presets_dir), "INI Files (*.ini)")
+        if path:
+            dest = self.presets_dir / Path(path).name
+            Path(path).replace(dest)
+            self.load_presets()
+
+    def export_preset(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(self, "Save preset", str(self.presets_dir / "preset.ini"), "INI Files (*.ini)")
+        if path:
+            with open(path, "w", encoding="utf-8") as f:
+                for i in range(self.list.count()):
+                    f.write(f"; {self.list.item(i).text()}\n")
+

--- a/ue_configurator/ui/project_chooser.py
+++ b/ue_configurator/ui/project_chooser.py
@@ -66,7 +66,8 @@ class ProjectChooser(QWidget):
         save_recent(projects[:10])
 
         cache = Path.home() / ".ue5_config_assistant" / "cvar_cache.json"
-        self.main_window = MainWindow(cache)  # type: ignore[attr-defined]
+        project_dir = Path(path).parent
+        self.main_window = MainWindow(cache, project_dir)  # type: ignore[attr-defined]
         self.main_window.show()
         self.close()
 


### PR DESCRIPTION
## Summary
- implement `ConfigDB` for `.ini` scanning and backups
- detect duplicate settings and comment out lower priority entries
- expose conflict and preset panes via `MainWindow`
- pass project directory from `ProjectChooser`
- add basic user settings loader
- test duplicate detection logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886240b3fb48323ab9094953a43f841