### PR TITLE
Implement metadata parsing in indexer

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -4,13 +4,20 @@ from pathlib import Path
 
 def test_index_headers(tmp_path: Path):
     header = tmp_path / "test.h"
-    header.write_text('IConsoleVariable::Register("r.Test", "Test desc", 0);')
+    header.write_text(
+        "// Category: Rendering\n// Range: 0-1\nIConsoleVariable::Register(\"r.Test\", 0, \"Test desc\");"
+    )
     result = index_headers(tmp_path)
     assert any(r["name"] == "r.Test" for r in result)
+    item = next(r for r in result if r["name"] == "r.Test")
+    assert item["default"] == "0"
+    assert item["category"] == "Rendering"
+    assert item["range"] == "0-1"
 
 
 def test_load_cache(tmp_path: Path):
     cache = tmp_path / "cache.json"
-    cache.write_text('[{"name": "r.Test", "description": "Test"}]')
+    cache.write_text('[{"name": "r.Test", "description": "Test", "default": "1", "category": "Cat", "range": "0-1"}]')
     data = load_cache(cache)
     assert data[0]["name"] == "r.Test"
+    assert data[0]["default"] == "1"


### PR DESCRIPTION
## Summary
- extend indexer regex patterns to capture default value
- parse preceding comments for category and valid range
- store `default`, `category`, and `range` fields when indexing
- update tests for new metadata handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f8aaad9083239bc74147f9ec3e3e