### PR TITLE
Implement metadata parsing in indexer

### DIFF
--- a/tests/test_config_db.py
+++ b/tests/test_config_db.py
@@ -43,5 +43,25 @@ def test_comment_and_save(tmp_path: Path):
     assert ";Key=1" in text or "#Key=1" in text
 
 
+def test_insert_and_resolve(tmp_path: Path):
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    ini1 = cfg / "DefaultGame.ini"
+    ini2 = cfg / "ProjectGame.ini"
+    write_ini(ini1, "[ConsoleVariables]\nr.Test=0\n")
+    write_ini(ini2, "[ConsoleVariables]\n")
+
+    db = ConfigDB()
+    db.load(cfg)
+    db.insert_setting("ConsoleVariables", "r.Test", "1", "ProjectGame.ini")
+    db.resolve_duplicate("ConsoleVariables", "r.Test", "delete")
+    db.save(cfg)
+
+    text2 = ini2.read_text().lower()
+    text1 = ini1.read_text().lower()
+    assert "r.test" in text2
+    assert "r.test" not in text1
+
+
 
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,16 +1,33 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from ue_configurator.indexer import index_headers, load_cache
+from ue_configurator.indexer import index_headers, load_cache, detect_engine_from_uproject
 from pathlib import Path
 
 def test_index_headers(tmp_path: Path):
     header = tmp_path / "test.h"
-    header.write_text('IConsoleVariable::Register("r.Test", "Test desc", 0);')
+    header.write_text(
+        "// Category: Rendering\n// Range: 0-1\nIConsoleVariable::Register(\"r.Test\", 0, \"Test desc\");"
+    )
     result = index_headers(tmp_path)
     assert any(r["name"] == "r.Test" for r in result)
+    item = next(r for r in result if r["name"] == "r.Test")
+    assert item["default"] == "0"
+    assert item["category"] == "Rendering"
+    assert item["range"] == "0-1"
 
 
 def test_load_cache(tmp_path: Path):
     cache = tmp_path / "cache.json"
-    cache.write_text('[{"name": "r.Test", "description": "Test"}]')
+    cache.write_text('[{"name": "r.Test", "description": "Test", "default": "1", "category": "Cat", "range": "0-1"}]')
     data = load_cache(cache)
     assert data[0]["name"] == "r.Test"
+    assert data[0]["default"] == "1"
+
+
+def test_detect_engine(tmp_path: Path):
+    engine = tmp_path / "Engine"
+    engine.mkdir()
+    proj = tmp_path / "Proj"
+    proj.mkdir()
+    (proj / "Proj.uproject").write_text('{"EngineAssociation": "%s"}' % engine)
+    found = detect_engine_from_uproject(proj)
+    assert found == engine

--- a/ue_configurator/indexer.py
+++ b/ue_configurator/indexer.py
@@ -5,12 +5,20 @@ from __future__ import annotations
 import re
 import json
 from pathlib import Path
-from typing import Iterable, List, Dict
+from typing import Iterable, List, Dict, Tuple
 
 import rich.progress
+import json as jsonlib
 
-REGISTER = re.compile(r'IConsoleVariable::Register[^\"]*\"(?P<name>[A-Za-z0-9_.]+)\".*?\"(?P<desc>[^\"]+)\"[^;]*;')
-UE_CVAR = re.compile(r'UE_CVAR_(?:INTEGER|FLOAT|STRING)\s*\(\s*\"(?P<name>[^\"]+)\"\s*,.*?\"(?P<desc>[^\"]+)\"')
+REGISTER = re.compile(
+    r'IConsoleVariable::Register\s*\(\s*"(?P<name>[A-Za-z0-9_.]+)"\s*,\s*(?P<default>[^,]+),\s*"(?P<desc>[^"]+)"',
+)
+UE_CVAR = re.compile(
+    r'UE_CVAR_(?:INTEGER|FLOAT|STRING)\s*\(\s*"(?P<name>[^"]+)"\s*,\s*(?P<default>[^,]+),\s*"(?P<desc>[^"]+)"',
+)
+
+COMMENT_CATEGORY = re.compile(r"Category:\s*(?P<val>.+)")
+COMMENT_RANGE = re.compile(r"Range:\s*(?P<val>.+)")
 
 
 def iter_headers(root: Path) -> Iterable[Path]:
@@ -18,18 +26,54 @@ def iter_headers(root: Path) -> Iterable[Path]:
         yield path
 
 
-def index_headers(root: Path) -> list[dict[str, str]]:
+def _parse_comment_metadata(lines: List[str], idx: int) -> Tuple[str | None, str | None]:
+    """Parse category and range from comment lines above ``idx``."""
+    category: str | None = None
+    valid_range: str | None = None
+    for j in range(idx - 1, max(-1, idx - 4), -1):
+        line = lines[j].strip()
+        if not line.startswith("//"):
+            break
+        comment = line[2:].strip()
+        m = COMMENT_CATEGORY.search(comment)
+        if m:
+            category = m.group("val").strip()
+        m = COMMENT_RANGE.search(comment)
+        if m:
+            valid_range = m.group("val").strip()
+    return category, valid_range
+
+
+def index_headers(root: Path, progress: rich.progress.Progress | None = None) -> list[dict[str, str]]:
     results = []
-    for header in iter_headers(root):
+    headers = list(iter_headers(root)) if progress else iter_headers(root)
+    task_id = None
+    if progress:
+        task_id = progress.add_task("Headers", total=len(headers))
+    for header in headers:
         text = header.read_text(errors="ignore")
-        for pattern in (REGISTER, UE_CVAR):
-            for match in pattern.finditer(text):
-                results.append({"name": match.group("name"), "description": match.group("desc"), "file": str(header)})
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            match = REGISTER.search(line) or UE_CVAR.search(line)
+            if match:
+                category, rng = _parse_comment_metadata(lines, idx)
+                results.append(
+                    {
+                        "name": match.group("name"),
+                        "description": match.group("desc"),
+                        "default": match.group("default").strip(),
+                        "category": category or "",
+                        "range": rng or "",
+                        "file": str(header),
+                    }
+                )
+        if progress and task_id is not None:
+            progress.advance(task_id)
     return results
 
 
-def build_cache(engine_root: Path, cache_file: Path) -> None:
-    data = index_headers(engine_root)
+def build_cache(engine_root: Path, cache_file: Path, progress: rich.progress.Progress | None = None) -> None:
+    data = index_headers(engine_root, progress)
     cache_file.write_text(json.dumps(data, indent=2))
 
 
@@ -42,6 +86,19 @@ def load_cache(cache_file: Path) -> List[Dict[str, str]]:
     return []
 
 
+def detect_engine_from_uproject(project_dir: Path) -> Path | None:
+    """Return engine root defined in a project's .uproject."""
+    for up in project_dir.glob("*.uproject"):
+        try:
+            data = jsonlib.loads(up.read_text())
+            assoc = data.get("EngineAssociation")
+            if assoc and Path(assoc).exists():
+                return Path(assoc)
+        except Exception:
+            continue
+    return None
+
+
 def main() -> None:
     import argparse
 
@@ -52,9 +109,7 @@ def main() -> None:
 
     progress = rich.progress.Progress()
     with progress:
-        task = progress.add_task("Indexing", total=None)
-        build_cache(args.engine_root, args.cache)
-        progress.update(task, completed=1)
+        build_cache(args.engine_root, args.cache, progress)
 
     print(f"Cache written to {args.cache}")
 

--- a/ue_configurator/ui/details_pane.py
+++ b/ue_configurator/ui/details_pane.py
@@ -2,21 +2,68 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QTextBrowser
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QTextBrowser,
+    QLineEdit,
+    QComboBox,
+    QPushButton,
+)
+
+from ..config_db import ConfigDB
 
 
 class DetailsPane(QWidget):
-    def __init__(self) -> None:
+    def __init__(self, db: ConfigDB | None = None) -> None:
         super().__init__()
+        self.db = db
         self.setWindowTitle("CVar Details")
         self.text = QTextBrowser()
+        self.value_edit = QLineEdit()
+        self.target_box = QComboBox()
+        self.add_btn = QPushButton("Add to Config")
         layout = QVBoxLayout(self)
         layout.addWidget(self.text)
+        layout.addWidget(self.value_edit)
+        layout.addWidget(self.target_box)
+        layout.addWidget(self.add_btn)
+
+        self.current_item: Dict[str, str] | None = None
+        self.add_btn.clicked.connect(self._add)
+
+    def set_db(self, db: ConfigDB) -> None:
+        self.db = db
+        self._populate_targets()
+
+    def _populate_targets(self) -> None:
+        if not self.db:
+            return
+        self.target_box.clear()
+        for name in self.db.available_targets():
+            self.target_box.addItem(name)
 
     def show_details(self, info: Dict[str, str]) -> None:
+        self.current_item = info
         desc = info.get("description", "")
         file = info.get("file", "")
+        rng = info.get("range", "")
+        default = info.get("default", "")
         content = f"<b>{info.get('name')}</b><br>{desc}<br><i>{file}</i>"
+        if rng:
+            content += f"<br>Range: {rng}"
+        if default:
+            content += f"<br>Default: {default}"
         self.text.setHtml(content)
+        self.value_edit.setText(default)
+        self._populate_targets()
+
+    def _add(self) -> None:
+        if not self.db or not self.current_item:
+            return
+        target = self.target_box.currentText()
+        value = self.value_edit.text()
+        name = self.current_item.get("name", "")
+        self.db.insert_setting("ConsoleVariables", name, value, target)

--- a/ue_configurator/ui/main_window.py
+++ b/ue_configurator/ui/main_window.py
@@ -25,8 +25,8 @@ class MainWindow(QMainWindow):
         if config_dir.exists():
             self.db.load(config_dir)
 
-        self.search = SearchPane(cache_file)
-        self.details = DetailsPane()
+        self.search = SearchPane(cache_file, project_dir)
+        self.details = DetailsPane(self.db)
 
         self.search.table.itemSelectionChanged.connect(self.show_details)
 
@@ -56,11 +56,7 @@ class MainWindow(QMainWindow):
         if not rows:
             return
         row = rows[0].row()
-        item = {
-            "name": self.search.table.item(row, 0).text(),
-            "description": self.search.table.item(row, 1).text(),
-            "file": self.search.table.item(row, 2).text(),
-        }
+        item = self.search.data[row]
         self.details.show_details(item)
 
     def show_conflicts(self) -> None:
@@ -68,6 +64,12 @@ class MainWindow(QMainWindow):
         pane.show()
 
     def save_config(self) -> None:
+        ok, msg = self.db.validate()
+        if not ok:
+            from PySide6.QtWidgets import QMessageBox
+
+            QMessageBox.warning(self, "Validation Error", msg or "Invalid config")
+            return
         config_dir = self.project_dir / "Config"
         self.db.save(config_dir)
 

--- a/ue_configurator/ui/preset_pane.py
+++ b/ue_configurator/ui/preset_pane.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from PySide6.QtWidgets import (
     QWidget,
@@ -10,6 +11,7 @@ from PySide6.QtWidgets import (
     QListWidget,
     QPushButton,
     QFileDialog,
+    QMessageBox,
 )
 
 
@@ -46,8 +48,9 @@ class PresetPane(QWidget):
         path, _ = QFileDialog.getOpenFileName(self, "Select preset", str(self.presets_dir), "INI Files (*.ini)")
         if path:
             dest = self.presets_dir / Path(path).name
-            Path(path).replace(dest)
+            shutil.copy2(path, dest)
             self.db.merge_preset(dest)
+            QMessageBox.information(self, "Preset Imported", f"Imported {dest.name}")
             self.load_presets()
 
     def export_preset(self) -> None:

--- a/ue_configurator/ui/search_pane.py
+++ b/ue_configurator/ui/search_pane.py
@@ -9,33 +9,41 @@ from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QLineEdit,
+    QComboBox,
     QTableWidget,
     QTableWidgetItem,
     QHeaderView,
 )
 
-from ..indexer import load_cache, build_cache
+import rich.progress
+from ..indexer import load_cache, build_cache, detect_engine_from_uproject
 
 
 class SearchPane(QWidget):
-    def __init__(self, cache_file: Path) -> None:
+    def __init__(self, cache_file: Path, project_dir: Path | None = None) -> None:
         super().__init__()
         self.cache_file = cache_file
+        self.project_dir = project_dir
         self.setWindowTitle("UE Config Assistant - Search")
 
         self.search_box = QLineEdit()
+        self.category_box = QComboBox()
+        self.category_box.addItem("All")
         self.table = QTableWidget(0, 3)
         self.table.setHorizontalHeaderLabels(["Name", "Description", "File"])
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
 
         layout = QVBoxLayout(self)
         layout.addWidget(self.search_box)
+        layout.addWidget(self.category_box)
         layout.addWidget(self.table)
 
         self.search_box.textChanged.connect(self.update_filter)
+        self.category_box.currentTextChanged.connect(self.update_filter)
 
         self.data: List[Dict[str, str]] = []
         self.load_data()
+        self._populate_categories()
         self.update_table()
 
     def load_data(self) -> None:
@@ -43,9 +51,15 @@ class SearchPane(QWidget):
             self.data = load_cache(self.cache_file)
         else:
             self.cache_file.parent.mkdir(parents=True, exist_ok=True)
-            engine_root = self.ask_engine_root()
+            engine_root = None
+            if self.project_dir:
+                engine_root = detect_engine_from_uproject(self.project_dir)
+            if not engine_root:
+                engine_root = self.ask_engine_root()
             if engine_root:
-                build_cache(Path(engine_root), self.cache_file)
+                progress = rich.progress.Progress()
+                with progress:
+                    build_cache(Path(engine_root), self.cache_file, progress)
                 self.data = load_cache(self.cache_file)
 
     def ask_engine_root(self) -> str | None:
@@ -54,8 +68,19 @@ class SearchPane(QWidget):
         path = QFileDialog.getExistingDirectory(self, "Select Engine Root")
         return path or None
 
+    def _populate_categories(self) -> None:
+        cats = sorted({d.get("category", "") for d in self.data if d.get("category")})
+        for cat in cats:
+            if self.category_box.findText(cat) == -1:
+                self.category_box.addItem(cat)
+
     def update_filter(self, text: str) -> None:
-        filtered = [d for d in self.data if text.lower() in d["name"].lower() or text.lower() in d["description"].lower()]
+        category = self.category_box.currentText()
+        filtered = []
+        for d in self.data:
+            if text.lower() in d["name"].lower() or text.lower() in d["description"].lower():
+                if category == "All" or d.get("category", "") == category:
+                    filtered.append(d)
         self.update_table(filtered)
 
     def update_table(self, items: List[Dict[str, str]] | None = None) -> None:


### PR DESCRIPTION
## Summary
- extend indexer regex patterns to capture default value
- parse preceding comments for category and valid range comment parsing
- store `default`, `category`, and `range` fields when indexing
- add dropdown filter in `SearchPane` for categories
- update tests for new metadata handling
- add add-to-config workflow and conflict resolution options
- implement preset import copy and engine auto-detection
- provide validation before save and progress during indexing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f8aaad9083239bc74147f9ec3e3e