### PR TITLE
Fix settings persistence and header indexing

### DIFF
--- a/ue_configurator/indexer.py
+++ b/ue_configurator/indexer.py
@@ -45,7 +45,6 @@ def _parse_comment_metadata(lines: List[str], idx: int) -> Tuple[str | None, str
 
 
 def index_headers(root: Path, progress: rich.progress.Progress | None = None) -> list[dict[str, str]]:
-def index_headers(root: Path) -> list[dict[str, str]]:
     results = []
     headers = list(iter_headers(root)) if progress else iter_headers(root)
     task_id = None

--- a/ue_configurator/settings.py
+++ b/ue_configurator/settings.py
@@ -20,4 +20,6 @@ def load_settings() -> Dict[str, Any]:
 
 def save_settings(data: Dict[str, Any]) -> None:
     SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SETTINGS_FILE.write_text(json.dumps(data, indent=2))
+    existing = load_settings()
+    existing.update(data)
+    SETTINGS_FILE.write_text(json.dumps(existing, indent=2))


### PR DESCRIPTION
## Summary
- resolve duplicate definition in `index_headers`
- merge new user settings with existing data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b56dc7ea48323a4350d351e384595