### PR TITLE
Add console variable scraper from online docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ PySide6
 configupdater
 rich
 pytest
+requests
+beautifulsoup4

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,35 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from ue_configurator.indexer import parse_console_variable_page, scrape_console_variables
+
+SAMPLE_HTML = """
+<table class=\"table\">
+<thead><tr><th>Variable</th><th>Default Value</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>r.Test</code></td><td><code>0</code></td><td>Test variable</td></tr>
+</tbody>
+</table>
+<table class=\"table\">
+<thead><tr><th>Variable</th><th>Default Value</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>r.Test2</code></td><td><code>1</code></td><td>Second test variable</td></tr>
+</tbody>
+</table>
+"""
+
+def test_parse_console_variable_page():
+    data = parse_console_variable_page(SAMPLE_HTML)
+    assert len(data) == 2
+    assert data[0]["name"] == "r.Test"
+    assert data[1]["name"] == "r.Test2"
+    assert data[1]["description"] == "Second test variable"
+
+def test_scrape_console_variables(monkeypatch):
+    class DummyResp:
+        text = SAMPLE_HTML
+        def raise_for_status(self):
+            return None
+    def fake_get(url, headers, timeout):
+        return DummyResp()
+    monkeypatch.setattr("ue_configurator.indexer.requests.get", fake_get)
+    data = scrape_console_variables("5.6")
+    assert [d["name"] for d in data] == ["r.Test", "r.Test2"]


### PR DESCRIPTION
## Summary
- add HTML parser and scraper for console variables from Epic's documentation
- document new requests and beautifulsoup4 dependencies
- test parser and scraping logic with sample HTML

## Testing
- `pytest`
- `python - <<'PY'
import requests
from ue_configurator.indexer import parse_console_variable_page
url='https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-console-variables-reference?application_version=5.4'
html=requests.get(url, headers={'User-Agent': 'Mozilla/5.0'}).text
rows = parse_console_variable_page(html)
print('rows', len(rows))
missing_desc = sum(1 for r in rows if not r['description'])
print('missing desc', missing_desc)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689208a623108323b2fbe6f147104602