### PR TITLE
Allow duplicate ini entries

### DIFF
--- a/tests/test_config_db.py
+++ b/tests/test_config_db.py
@@ -63,5 +63,23 @@ def test_insert_and_resolve(tmp_path: Path):
     assert "r.test" not in text1
 
 
+def test_load_ini_with_internal_duplicates(tmp_path: Path) -> None:
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    ini = cfg / "DefaultGame.ini"
+    # same key appears twice in the file which previously triggered
+    # ``DuplicateOptionError`` during loading.
+    write_ini(ini, "[Section]\nKey=1\nKey=2\n")
+
+    db = ConfigDB()
+    # should not raise
+    db.load(cfg)
+    assert db.files, "ini file loaded"
+    dups = db.find_duplicates()
+    assert ("Section", "key") in dups
+    # same file is returned twice for the duplicate entries
+    assert len(dups[("Section", "key")]) == 2
+
+
 
 

--- a/ue_configurator/config_db.py
+++ b/ue_configurator/config_db.py
@@ -22,7 +22,11 @@ class IniFile:
 
     def __init__(self, path: Path) -> None:
         self.path = path
-        self.updater = ConfigUpdater()
+        # ``configupdater`` raises ``DuplicateOptionError`` when the same option
+        # appears multiple times within a section.  Some real world UE ini files
+        # contain such duplicates, so read with ``strict=False`` to keep loading
+        # resilient and let our own duplicate detection handle conflicts.
+        self.updater = ConfigUpdater(strict=False)
         if path.exists():
             self.updater.read(str(path))
 
@@ -161,7 +165,7 @@ class ConfigDB:
         if not self.files:
             return
         target = self.files[-1]
-        updater = ConfigUpdater()
+        updater = ConfigUpdater(strict=False)
         updater.read(str(preset_path))
         for sec in updater.sections():
             if not target.updater.has_section(sec):
@@ -171,7 +175,7 @@ class ConfigDB:
 
     def export_preset(self, path: Path) -> None:
         """Export current merged config to ``path``."""
-        merged = ConfigUpdater()
+        merged = ConfigUpdater(strict=False)
         for ini in self.files:
             for sec in ini.updater.sections():
                 if not merged.has_section(sec):


### PR DESCRIPTION
## Summary
- use `ConfigUpdater(strict=False)` so that UE ini files with repeated keys load without errors
- add regression test ensuring duplicate keys inside a single ini file are detected instead of crashing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689996cc1e64832385c7adf29248c045