### PR TITLE
Add referer header for docs scraping

### DIFF
--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -30,11 +30,15 @@ def test_scrape_console_variables(monkeypatch):
         text = SAMPLE_HTML
         def raise_for_status(self):
             return None
+    captured = {}
     def fake_get(url, headers, timeout):
+        captured.update(headers)
         return DummyResp()
     monkeypatch.setattr("ue_configurator.indexer.requests.get", fake_get)
     data = scrape_console_variables("5.6")
     assert [d["name"] for d in data] == ["r.Test", "r.Test2"]
+    # Ensure that our request includes the additional browser-like headers
+    assert captured.get("Referer") == "https://dev.epicgames.com/documentation/"
 
 
 def test_build_cache_online(monkeypatch, tmp_path: Path):

--- a/ue_configurator/indexer.py
+++ b/ue_configurator/indexer.py
@@ -77,6 +77,9 @@ def scrape_console_variables(version: str) -> List[Dict[str, str]]:
         ),
         "Accept-Language": "en-US,en;q=0.5",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        # Some regions appear to require a referer header for the request to
+        # succeed.  Provide one to further mimic a real browser request.
+        "Referer": "https://dev.epicgames.com/documentation/",
     }
     resp = requests.get(url, headers=headers, timeout=10)
     try:


### PR DESCRIPTION
## Summary
- mimic browser requests by adding a referer header when scraping Epic docs
- test that Referer header is passed to requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999aebf3f483238d6929589cdefa46