### PR TITLE
Add logging and retain UI panes for debugging

### DIFF
--- a/ue_configurator/app.py
+++ b/ue_configurator/app.py
@@ -1,11 +1,21 @@
 """Application entry point for UE Config Assistant."""
 
+import logging
+import sys
 from PySide6.QtWidgets import QApplication
 
 from .ui.project_chooser import ProjectChooser
 
 
-def main():
+def main() -> None:
+    """Launch the application and configure basic logging."""
+    logging.basicConfig(level=logging.INFO)
+
+    def handle_exception(exc_type, exc, tb) -> None:
+        logging.exception("Uncaught exception", exc_info=(exc_type, exc, tb))
+
+    sys.excepthook = handle_exception
+
     app = QApplication([])
     chooser = ProjectChooser()
     chooser.show()

--- a/ue_configurator/ui/main_window.py
+++ b/ue_configurator/ui/main_window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from PySide6.QtWidgets import QSplitter, QMainWindow
@@ -22,6 +23,8 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("UE Config Assistant")
         self.project_dir = project_dir
         self.db = ConfigDB()
+        self.conflict_pane: ConflictPane | None = None
+        self.preset_pane: PresetPane | None = None
         config_dir = project_dir / "Config"
         if config_dir.exists():
             self.db.load(config_dir)
@@ -61,8 +64,11 @@ class MainWindow(QMainWindow):
         self.details.show_details(item)
 
     def show_conflicts(self) -> None:
-        pane = ConflictPane(self.db)
-        pane.show()
+        try:
+            self.conflict_pane = ConflictPane(self.db)
+            self.conflict_pane.show()
+        except Exception:
+            logging.exception("Failed to open conflict pane")
 
     def save_config(self) -> None:
         ok, msg = self.db.validate()
@@ -79,6 +85,9 @@ class MainWindow(QMainWindow):
         super().closeEvent(event)
 
     def show_presets(self) -> None:
-        presets = self.project_dir / "Presets"
-        pane = PresetPane(presets, self.db)
-        pane.show()
+        try:
+            presets = self.project_dir / "Presets"
+            self.preset_pane = PresetPane(presets, self.db)
+            self.preset_pane.show()
+        except Exception:
+            logging.exception("Failed to open presets pane")

--- a/ue_configurator/ui/preset_pane.py
+++ b/ue_configurator/ui/preset_pane.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 import shutil
 
@@ -39,22 +40,40 @@ class PresetPane(QWidget):
         self.load_presets()
 
     def load_presets(self) -> None:
-        self.list.clear()
-        self.presets_dir.mkdir(parents=True, exist_ok=True)
-        for p in self.presets_dir.glob("*.ini"):
-            self.list.addItem(p.name)
+        try:
+            self.list.clear()
+            self.presets_dir.mkdir(parents=True, exist_ok=True)
+            for p in self.presets_dir.glob("*.ini"):
+                self.list.addItem(p.name)
+        except Exception:
+            logging.exception("Failed to load presets")
 
     def import_preset(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Select preset", str(self.presets_dir), "INI Files (*.ini)")
-        if path:
-            dest = self.presets_dir / Path(path).name
-            shutil.copy2(path, dest)
-            self.db.merge_preset(dest)
-            QMessageBox.information(self, "Preset Imported", f"Imported {dest.name}")
-            self.load_presets()
+        try:
+            path, _ = QFileDialog.getOpenFileName(
+                self, "Select preset", str(self.presets_dir), "INI Files (*.ini)"
+            )
+            if path:
+                dest = self.presets_dir / Path(path).name
+                shutil.copy2(path, dest)
+                self.db.merge_preset(dest)
+                QMessageBox.information(
+                    self, "Preset Imported", f"Imported {dest.name}"
+                )
+                self.load_presets()
+        except Exception:
+            logging.exception("Failed to import preset")
 
     def export_preset(self) -> None:
-        path, _ = QFileDialog.getSaveFileName(self, "Save preset", str(self.presets_dir / "preset.ini"), "INI Files (*.ini)")
-        if path:
-            self.db.export_preset(Path(path))
+        try:
+            path, _ = QFileDialog.getSaveFileName(
+                self,
+                "Save preset",
+                str(self.presets_dir / "preset.ini"),
+                "INI Files (*.ini)",
+            )
+            if path:
+                self.db.export_preset(Path(path))
+        except Exception:
+            logging.exception("Failed to export preset")
 


### PR DESCRIPTION
## Summary
- Add basic logging setup and uncaught exception handler in the application entry point
- Keep duplicate and preset panes alive and log errors when opening them
- Wrap preset and conflict pane operations in try/except blocks with logging for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999b6a6eb88323b65990481bd99564