### PR TITLE
Add Cloudflare-aware fallback for console variable scraping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ configupdater
 rich
 pytest
 requests
+cloudscraper
 beautifulsoup4


### PR DESCRIPTION
## Summary
- fall back to cloudscraper when the online console variable docs return 403
- declare cloudscraper as a dependency
- test Cloudflare fallback in the scraper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68999d1cfae48323b625326c94b9abef