### PR TITLE
Add ability to ignore ini files

### DIFF
--- a/ue_configurator/ui/files_pane.py
+++ b/ue_configurator/ui/files_pane.py
@@ -1,0 +1,38 @@
+"""UI pane for toggling active ini files."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QListWidget, QListWidgetItem
+from PySide6.QtCore import Qt
+
+from ..config_db import ConfigDB
+
+
+class FilesPane(QWidget):
+    def __init__(self, db: ConfigDB, on_change: Callable[[], None] | None = None) -> None:
+        super().__init__()
+        self.db = db
+        self.on_change = on_change
+        self.setWindowTitle("Config Files")
+        self.list = QListWidget()
+        self.list.itemChanged.connect(self._toggle)
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.list)
+        self.populate()
+
+    def populate(self) -> None:
+        self.list.clear()
+        for name, enabled in self.db.list_files():
+            item = QListWidgetItem(name)
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            item.setCheckState(Qt.Checked if enabled else Qt.Unchecked)
+            self.list.addItem(item)
+
+    def _toggle(self, item: QListWidgetItem) -> None:
+        name = item.text()
+        enabled = item.checkState() == Qt.Checked
+        self.db.set_file_enabled(name, enabled)
+        if self.on_change:
+            self.on_change()

--- a/ue_configurator/ui/main_window.py
+++ b/ue_configurator/ui/main_window.py
@@ -11,6 +11,7 @@ from PySide6.QtGui import QAction
 from ..config_db import ConfigDB
 from .conflict_pane import ConflictPane
 from .preset_pane import PresetPane
+from .files_pane import FilesPane
 from ..settings import load_settings, save_settings
 
 from .search_pane import SearchPane
@@ -25,6 +26,7 @@ class MainWindow(QMainWindow):
         self.db = ConfigDB()
         self.conflict_pane: ConflictPane | None = None
         self.preset_pane: PresetPane | None = None
+        self.files_pane: FilesPane | None = None
         config_dir = project_dir / "Config"
         if config_dir.exists():
             self.db.load(config_dir)
@@ -45,10 +47,13 @@ class MainWindow(QMainWindow):
         conflict_action.triggered.connect(self.show_conflicts)
         preset_action = QAction("Presets", self)
         preset_action.triggered.connect(self.show_presets)
+        files_action = QAction("Config Files", self)
+        files_action.triggered.connect(self.show_files)
         save_action = QAction("Save", self)
         save_action.triggered.connect(self.save_config)
         self.menuBar().addAction(conflict_action)
         self.menuBar().addAction(preset_action)
+        self.menuBar().addAction(files_action)
         self.menuBar().addAction(save_action)
 
         settings = load_settings()
@@ -91,3 +96,10 @@ class MainWindow(QMainWindow):
             self.preset_pane.show()
         except Exception:
             logging.exception("Failed to open presets pane")
+
+    def show_files(self) -> None:
+        try:
+            self.files_pane = FilesPane(self.db, self.details._populate_targets)
+            self.files_pane.show()
+        except Exception:
+            logging.exception("Failed to open files pane")


### PR DESCRIPTION
## Summary
- Track enabled state for each ini file and filter all ConfigDB operations to active files only
- Add FilesPane to list discovered ini files and toggle which ones are active
- Expose config-file toggling from the main window and test ignoring logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999dbc870c8323b127dab2a638c191