### PR TITLE
Handle missing cloudscraper dependency

### DIFF
--- a/ue_configurator/indexer.py
+++ b/ue_configurator/indexer.py
@@ -11,7 +11,10 @@ import contextlib
 import rich.progress
 import json as jsonlib
 import requests
-import cloudscraper
+try:
+    import cloudscraper  # type: ignore
+except ModuleNotFoundError:
+    cloudscraper = None  # type: ignore
 from bs4 import BeautifulSoup
 
 REGISTER = re.compile(
@@ -85,8 +88,9 @@ def scrape_console_variables(version: str) -> List[Dict[str, str]]:
     resp = requests.get(url, headers=headers, timeout=10)
     if resp.status_code == 403:
         # Some environments sit behind Cloudflare protection which rejects
-        # generic requests.  Retry using cloudscraper which simulates a real
-        # browser more effectively.
+        # generic requests. Retry with cloudscraper if available.
+        if cloudscraper is None:
+            raise RuntimeError("HTTP 403 received; install 'cloudscraper' for retry")
         scraper = cloudscraper.create_scraper()
         resp = scraper.get(url, headers=headers, timeout=10)
     try:


### PR DESCRIPTION
## Summary
- Gracefully handle absence of optional `cloudscraper` dependency
- Clarify fallback logic for HTTP 403 responses during scraping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999faf87b88323a613010789db23f3