### PR TITLE
Add local engine indexing option

### DIFF
--- a/tests/test_search_pane.py
+++ b/tests/test_search_pane.py
@@ -1,0 +1,25 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import json
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+SearchPane = pytest.importorskip("ue_configurator.ui.search_pane").SearchPane
+QApplication = QtWidgets.QApplication
+
+
+def test_search_pane_uses_local_engine(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    engine_root = tmp_path / "Engine"
+    engine_root.mkdir()
+    project_dir = tmp_path / "Proj"
+    project_dir.mkdir()
+    (project_dir / "Proj.uproject").write_text(json.dumps({"EngineAssociation": str(engine_root)}))
+    captured = {}
+    def fake_build_cache(cache_file, engine_root=None, version="5.4", progress=None):
+        captured["engine_root"] = engine_root
+        cache_file.write_text("[]")
+    monkeypatch.setattr("ue_configurator.ui.search_pane.build_cache", fake_build_cache)
+    cache_file = tmp_path / "cache.json"
+    pane = SearchPane(cache_file, project_dir, use_local_engine=True)
+    assert captured["engine_root"] == engine_root

--- a/ue_configurator/ui/main_window.py
+++ b/ue_configurator/ui/main_window.py
@@ -19,7 +19,7 @@ from .details_pane import DetailsPane
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, cache_file: Path, project_dir: Path) -> None:
+    def __init__(self, cache_file: Path, project_dir: Path, use_local_engine: bool = False) -> None:
         super().__init__()
         self.setWindowTitle("UE Config Assistant")
         self.project_dir = project_dir
@@ -31,7 +31,7 @@ class MainWindow(QMainWindow):
         if config_dir.exists():
             self.db.load(config_dir)
 
-        self.search = SearchPane(cache_file, project_dir)
+        self.search = SearchPane(cache_file, project_dir, use_local_engine=use_local_engine)
         self.details = DetailsPane(self.db)
 
         self.search.table.itemSelectionChanged.connect(self.show_details)

--- a/ue_configurator/ui/project_chooser.py
+++ b/ue_configurator/ui/project_chooser.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QListWidget,
     QPushButton,
     QFileDialog,
+    QCheckBox,
 )
 
 from .main_window import MainWindow
@@ -43,9 +44,11 @@ class ProjectChooser(QWidget):
         self.layout = QVBoxLayout(self)
         self.recent = QListWidget()
         self.browse_btn = QPushButton("Browse for .uproject")
+        self.local_engine_chk = QCheckBox("Use local engine headers")
 
         self.layout.addWidget(self.recent)
         self.layout.addWidget(self.browse_btn)
+        self.layout.addWidget(self.local_engine_chk)
 
         self.browse_btn.clicked.connect(self.browse)
         self.recent.itemDoubleClicked.connect(self.open_recent)
@@ -73,7 +76,11 @@ class ProjectChooser(QWidget):
 
         cache = Path.home() / ".ue5_config_assistant" / "cvar_cache.json"
         project_dir = Path(path).parent
-        self.main_window = MainWindow(cache, project_dir)  # type: ignore[attr-defined]
+        self.main_window = MainWindow(
+            cache,
+            project_dir,
+            use_local_engine=self.local_engine_chk.isChecked(),
+        )  # type: ignore[attr-defined]
         self.main_window.show()
         save_settings({"chooser_geometry": self.saveGeometry().data().hex()})
         self.close()

--- a/ue_configurator/ui/search_pane.py
+++ b/ue_configurator/ui/search_pane.py
@@ -73,6 +73,8 @@ class SearchPane(QWidget):
                             engine_root=Path(engine_root),
                             progress=progress,
                         )
+                else:
+                    build_cache(self.cache_file, version=self.engine_version)
             else:
                 build_cache(self.cache_file, version=self.engine_version)
             self.data = load_cache(self.cache_file)


### PR DESCRIPTION
## Summary
- add ProjectChooser checkbox to index CVars from local engine headers
- plumb local-engine choice through MainWindow into SearchPane
- fall back to online documentation when engine root isn't provided
- cover SearchPane local-engine behaviour with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899a5364a748323b62094c09dda62ef