### PR TITLE
Run build_cache in background thread with progress

### DIFF
--- a/tests/test_search_pane.py
+++ b/tests/test_search_pane.py
@@ -22,4 +22,7 @@ def test_search_pane_uses_local_engine(tmp_path, monkeypatch):
     monkeypatch.setattr("ue_configurator.ui.search_pane.build_cache", fake_build_cache)
     cache_file = tmp_path / "cache.json"
     pane = SearchPane(cache_file, project_dir, use_local_engine=True)
+    if pane._thread is not None:
+        pane._thread.wait()
+        app.processEvents()
     assert captured["engine_root"] == engine_root


### PR DESCRIPTION
## Summary
- Run `build_cache` in a `QThread` so the UI stays responsive
- Show a modal `QProgressDialog` that updates as the cache builds
- Reload the cache on completion and report failures with `QMessageBox`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dad1ba9208323b02afc9094e1c840