### PR TITLE
Run cache build in background thread with progress

### DIFF
--- a/ue_configurator/ui/search_pane.py
+++ b/ue_configurator/ui/search_pane.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Dict
 
-from PySide6.QtCore import Qt, QSortFilterProxyModel
+from PySide6.QtCore import (
+    Qt,
+    QSortFilterProxyModel,
+    QThread,
+    QObject,
+    Signal,
+    QEventLoop,
+)
 from PySide6.QtGui import QStandardItemModel, QStandardItem
 from PySide6.QtWidgets import (
     QWidget,
@@ -14,9 +21,10 @@ from PySide6.QtWidgets import (
     QComboBox,
     QTableView,
     QHeaderView,
+    QProgressDialog,
+    QMessageBox,
 )
 
-import rich.progress
 from ..indexer import load_cache, build_cache, detect_engine_from_uproject
 
 
@@ -46,6 +54,59 @@ class SearchFilterProxyModel(QSortFilterProxyModel):
         text_match = self._text in name or self._text in desc
         category_match = self._category == "All" or category == self._category
         return text_match and category_match
+
+
+class _ProgressAdapter(QObject):
+    """Adapter to translate indexer progress callbacks into Qt signals."""
+
+    changed = Signal(int, int)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._total = 0
+        self._value = 0
+
+    def add_task(self, _desc: str, total: int = 0) -> int:
+        self._total = total
+        self._value = 0
+        self.changed.emit(self._value, self._total)
+        return 0
+
+    def advance(self, _task_id: int) -> None:
+        self._value += 1
+        self.changed.emit(self._value, self._total)
+
+
+class BuildCacheWorker(QObject):
+    """Worker object running ``build_cache`` in a separate thread."""
+
+    progress = Signal(int, int)
+    finished = Signal(bool, str)
+
+    def __init__(
+        self,
+        cache_file: Path,
+        engine_root: Path | None,
+        version: str,
+    ) -> None:
+        super().__init__()
+        self.cache_file = cache_file
+        self.engine_root = engine_root
+        self.version = version
+
+    def run(self) -> None:
+        adapter = _ProgressAdapter()
+        adapter.changed.connect(self.progress.emit)
+        try:
+            build_cache(
+                cache_file=self.cache_file,
+                engine_root=self.engine_root,
+                version=self.version,
+                progress=adapter,
+            )
+            self.finished.emit(True, "")
+        except Exception as exc:  # pragma: no cover - network/IO failures
+            self.finished.emit(False, str(exc))
 
 
 class SearchPane(QWidget):
@@ -89,33 +150,27 @@ class SearchPane(QWidget):
 
         self.data: List[Dict[str, str]] = []
         self.load_data()
-        self._populate_categories()
-        self.update_table()
 
     def load_data(self) -> None:
         if self.cache_file.exists():
             self.data = load_cache(self.cache_file)
-        else:
-            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
-            if self.use_local_engine:
-                engine_root = None
-                if self.project_dir:
-                    engine_root = detect_engine_from_uproject(self.project_dir)
-                if not engine_root:
-                    engine_root = self.ask_engine_root()
-                if engine_root:
-                    progress = rich.progress.Progress()
-                    with progress:
-                        build_cache(
-                            cache_file=self.cache_file,
-                            engine_root=Path(engine_root),
-                            progress=progress,
-                        )
-                else:
-                    build_cache(self.cache_file, version=self.engine_version)
-            else:
-                build_cache(self.cache_file, version=self.engine_version)
-            self.data = load_cache(self.cache_file)
+            self._populate_categories()
+            self.update_table()
+            return
+
+        self.cache_file.parent.mkdir(parents=True, exist_ok=True)
+        engine_root: Path | None = None
+        if self.use_local_engine:
+            if self.project_dir:
+                root = detect_engine_from_uproject(self.project_dir)
+                if root:
+                    engine_root = Path(root)
+            if engine_root is None:
+                chosen = self.ask_engine_root()
+                if chosen:
+                    engine_root = Path(chosen)
+
+        self._build_cache(engine_root)
 
     def ask_engine_root(self) -> str | None:
         from PySide6.QtWidgets import QFileDialog
@@ -145,3 +200,59 @@ class SearchPane(QWidget):
             file_item = QStandardItem(item.get("file", ""))
             self.model.appendRow([name, desc, file_item])
         self.table.resizeRowsToContents()
+
+    # ------------------------------------------------------------------
+    # Cache building helpers
+    # ------------------------------------------------------------------
+
+    def _build_cache(self, engine_root: Path | None) -> None:
+        """Run ``build_cache`` in a background thread with progress dialog."""
+
+        self.progress_dialog = QProgressDialog("Building cache...", "", 0, 0, self)
+        self.progress_dialog.setWindowModality(Qt.ApplicationModal)
+        self.progress_dialog.setCancelButton(None)
+        self.progress_dialog.show()
+
+        self._thread = QThread(self)
+        worker = BuildCacheWorker(self.cache_file, engine_root, self.engine_version)
+        worker.moveToThread(self._thread)
+        worker.progress.connect(self._update_progress)
+        worker.finished.connect(self.progress_dialog.close)
+        worker.finished.connect(self._thread.quit)
+
+        result: dict[str, str | bool] = {}
+
+        def _finished(success: bool, msg: str) -> None:
+            result["success"] = success
+            result["msg"] = msg
+
+        worker.finished.connect(_finished)
+
+        self._thread.started.connect(worker.run)
+        self._thread.start()
+
+        loop = QEventLoop()
+        worker.finished.connect(loop.quit)
+        loop.exec()
+
+        self._thread.wait()
+        worker.deleteLater()
+        self._thread.deleteLater()
+
+        if result.get("success"):
+            self.data = load_cache(self.cache_file)
+            self._populate_categories()
+            self.update_table()
+        else:
+            QMessageBox.critical(
+                self,
+                "Cache Error",
+                f"Failed to build cache: {result.get('msg', '')}",
+            )
+
+    def _update_progress(self, value: int, total: int) -> None:
+        if total:
+            self.progress_dialog.setMaximum(total)
+            self.progress_dialog.setValue(value)
+        else:
+            self.progress_dialog.setRange(0, 0)


### PR DESCRIPTION
## Summary
- Run cache building in a dedicated `QThread` to keep UI responsive
- Show a modal `QProgressDialog` with updates during cache generation
- Reload cache on success and report failures via `QMessageBox`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc5908420832387c79fd7e50aa721