### PR TITLE
Infer CVar types and validate DetailsPane input

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+from ue_configurator.ui.utils import infer_cvar_type
+
+
+def test_infer_int_range():
+    dtype, vmin, vmax, options = infer_cvar_type("0-10", "5")
+    assert dtype == "int" and vmin == 0 and vmax == 10 and options is None
+
+
+def test_infer_float_default():
+    dtype, vmin, vmax, options = infer_cvar_type("", "0.5")
+    assert dtype == "float" and options is None
+
+
+def test_infer_enum_string():
+    dtype, vmin, vmax, options = infer_cvar_type("Low|High", "Low")
+    assert dtype == "str" and options == ["Low", "High"]
+

--- a/ue_configurator/ui/details_pane.py
+++ b/ue_configurator/ui/details_pane.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, cast
+import re
 
+from PySide6.QtCore import QRegularExpression
+from PySide6.QtGui import QRegularExpressionValidator
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -11,9 +14,12 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QComboBox,
     QPushButton,
+    QSpinBox,
+    QDoubleSpinBox,
 )
 
 from ..config_db import ConfigDB
+from .utils import infer_cvar_type
 
 
 class DetailsPane(QWidget):
@@ -22,14 +28,15 @@ class DetailsPane(QWidget):
         self.db = db
         self.setWindowTitle("CVar Details")
         self.text = QTextBrowser()
-        self.value_edit = QLineEdit()
+        self.value_edit: QWidget = QLineEdit()
         self.target_box = QComboBox()
         self.add_btn = QPushButton("Add to Config")
-        layout = QVBoxLayout(self)
-        layout.addWidget(self.text)
-        layout.addWidget(self.value_edit)
-        layout.addWidget(self.target_box)
-        layout.addWidget(self.add_btn)
+        self.add_btn.setEnabled(False)
+        self._layout = QVBoxLayout(self)
+        self._layout.addWidget(self.text)
+        self._layout.addWidget(self.value_edit)
+        self._layout.addWidget(self.target_box)
+        self._layout.addWidget(self.add_btn)
 
         self.current_item: Dict[str, str] | None = None
         self.add_btn.clicked.connect(self._add)
@@ -57,13 +64,72 @@ class DetailsPane(QWidget):
         if default:
             content += f"<br>Default: {default}"
         self.text.setHtml(content)
-        self.value_edit.setText(default)
+        dtype, min_val, max_val, options = infer_cvar_type(rng, default)
+        self._setup_value_edit(dtype, min_val, max_val, options, default)
         self._populate_targets()
+        self._update_add_enabled()
+
+    def _setup_value_edit(
+        self,
+        dtype: str,
+        min_val: float | None,
+        max_val: float | None,
+        options: List[str] | None,
+        default: str,
+    ) -> None:
+        """Configure the input widget based on inferred type."""
+        old = self.value_edit
+        if dtype == "int":
+            widget = QSpinBox()
+            if min_val is not None:
+                widget.setMinimum(int(min_val))
+            if max_val is not None:
+                widget.setMaximum(int(max_val))
+            try:
+                widget.setValue(int(float(default)))
+            except Exception:
+                pass
+            widget.valueChanged.connect(lambda _=0: self._update_add_enabled())
+        elif dtype == "float":
+            widget = QDoubleSpinBox()
+            if min_val is not None:
+                widget.setMinimum(float(min_val))
+            if max_val is not None:
+                widget.setMaximum(float(max_val))
+            try:
+                widget.setValue(float(default))
+            except Exception:
+                pass
+            widget.valueChanged.connect(lambda _=0: self._update_add_enabled())
+        else:
+            line = QLineEdit()
+            if options:
+                pattern = "|".join(map(re.escape, options))
+                regex = QRegularExpression(f"^(?:{pattern})$")
+                line.setValidator(QRegularExpressionValidator(regex, line))
+            line.setText(default)
+            line.textChanged.connect(lambda _=0: self._update_add_enabled())
+            widget = line
+
+        self._layout.replaceWidget(old, widget)
+        old.deleteLater()
+        self.value_edit = widget
+
+    def _current_value(self) -> str:
+        if isinstance(self.value_edit, (QSpinBox, QDoubleSpinBox)):
+            return str(self.value_edit.value())
+        return cast(QLineEdit, self.value_edit).text()
+
+    def _update_add_enabled(self) -> None:
+        valid = True
+        if isinstance(self.value_edit, QLineEdit):
+            valid = self.value_edit.hasAcceptableInput() and bool(self.value_edit.text())
+        self.add_btn.setEnabled(valid)
 
     def _add(self) -> None:
         if not self.db or not self.current_item:
             return
         target = self.target_box.currentText()
-        value = self.value_edit.text()
+        value = self._current_value()
         name = self.current_item.get("name", "")
         self.db.insert_setting("ConsoleVariables", name, value, target)

--- a/ue_configurator/ui/utils.py
+++ b/ue_configurator/ui/utils.py
@@ -1,0 +1,59 @@
+"""Utility helpers for UI components."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+
+def infer_cvar_type(
+    range_str: str, default: str
+) -> Tuple[str, Optional[float], Optional[float], Optional[List[str]]]:
+    """Infer data type and range information for a CVar value.
+
+    Parameters
+    ----------
+    range_str:
+        Raw range string from the indexer (e.g. ``"0-1"`` or ``"Low|High"``).
+    default:
+        Default value string from the indexer.
+
+    Returns
+    -------
+    tuple
+        ``(dtype, minimum, maximum, options)`` where ``dtype`` is one of
+        ``"int"``, ``"float"`` or ``"str"``. ``options`` contains a list of
+        allowed string values when ``dtype`` is ``"str"`` and the range string
+        represents an enumeration.
+    """
+
+    range_str = range_str.strip()
+
+    # Try to parse a numeric range like ``0-1`` or ``0..1``.
+    num_match = re.match(
+        r"^\s*([+-]?\d+(?:\.\d+)?)\s*(?:-|\.\.)\s*([+-]?\d+(?:\.\d+)?)\s*$",
+        range_str,
+    )
+    if num_match:
+        start, end = num_match.groups()
+        if "." in start or "." in end:
+            return "float", float(start), float(end), None
+        return "int", int(start), int(end), None
+
+    # If the range isn't numeric, treat it as a set of string options
+    # separated by common delimiters (|, /, ,).
+    if range_str:
+        parts = [p.strip() for p in re.split(r"[|,/]", range_str) if p.strip()]
+        if len(parts) > 1:
+            return "str", None, None, parts
+
+    # Fall back to the default value to guess type when no range was parsed.
+    try:
+        if "." in default or "e" in default.lower():
+            float(default)
+            return "float", None, None, None
+        int(default)
+        return "int", None, None, None
+    except Exception:
+        return "str", None, None, None
+


### PR DESCRIPTION
## Summary
- infer CVar data type and bounds from range/default metadata
- swap DetailsPane input widgets to spin boxes or validated text fields based on inferred type
- disable Add button until value passes validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc945c8dc832391532400a85d97a5