### PR TITLE
Add context menu to open INI files

### DIFF
--- a/tests/test_files_pane.py
+++ b/tests/test_files_pane.py
@@ -1,0 +1,41 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from pathlib import Path
+import pytest
+
+QtWidgets = pytest.importorskip("PySide6.QtWidgets")
+QApplication = QtWidgets.QApplication
+FilesPane = pytest.importorskip("ue_configurator.ui.files_pane").FilesPane
+ConfigDB = pytest.importorskip("ue_configurator.config_db").ConfigDB
+QUrl = pytest.importorskip("PySide6.QtCore").QUrl
+
+
+def _make_db(tmp_path: Path) -> ConfigDB:
+    config_dir = tmp_path / "Config"
+    config_dir.mkdir()
+    (config_dir / "DefaultGame.ini").write_text("[/Script/Engine.Engine]\n")
+    db = ConfigDB()
+    db.load(config_dir)
+    return db
+
+
+def test_files_pane_tooltip_shows_full_path(tmp_path):
+    app = QApplication.instance() or QApplication([])
+    db = _make_db(tmp_path)
+    pane = FilesPane(db)
+    item = pane.list.item(0)
+    assert item.toolTip() == str(db.config_dir / item.text())
+
+
+def test_open_item_uses_desktop_services(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    db = _make_db(tmp_path)
+    pane = FilesPane(db)
+    item = pane.list.item(0)
+    captured = {}
+    def fake_open(url):
+        captured["url"] = url
+        return True
+    monkeypatch.setattr("PySide6.QtGui.QDesktopServices.openUrl", fake_open)
+    pane._open_item(item)
+    assert captured["url"].toLocalFile() == str(db.config_dir / item.text())

--- a/ue_configurator/ui/files_pane.py
+++ b/ue_configurator/ui/files_pane.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 from typing import Callable
+from pathlib import Path
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QListWidget, QListWidgetItem
-from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
+)
+from PySide6.QtGui import QDesktopServices
+from PySide6.QtCore import Qt, QPoint, QUrl
 
 from ..config_db import ConfigDB
 
@@ -18,6 +26,8 @@ class FilesPane(QWidget):
         self.setWindowTitle("Config Files")
         self.list = QListWidget()
         self.list.itemChanged.connect(self._toggle)
+        self.list.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.list.customContextMenuRequested.connect(self._context_menu)
         layout = QVBoxLayout(self)
         layout.addWidget(self.list)
         self.populate()
@@ -28,6 +38,12 @@ class FilesPane(QWidget):
             item = QListWidgetItem(name)
             item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
             item.setCheckState(Qt.Checked if enabled else Qt.Unchecked)
+            if self.db.config_dir:
+                path = self.db.config_dir / name
+            else:
+                path = Path(name)
+            item.setData(Qt.UserRole, path)
+            item.setToolTip(str(path))
             self.list.addItem(item)
 
     def _toggle(self, item: QListWidgetItem) -> None:
@@ -36,3 +52,18 @@ class FilesPane(QWidget):
         self.db.set_file_enabled(name, enabled)
         if self.on_change:
             self.on_change()
+
+    def _context_menu(self, pos: QPoint) -> None:
+        item = self.list.itemAt(pos)
+        if not item:
+            return
+        menu = QMenu(self)
+        open_action = menu.addAction("Open in Editor")
+        action = menu.exec(self.list.mapToGlobal(pos))
+        if action == open_action:
+            self._open_item(item)
+
+    def _open_item(self, item: QListWidgetItem) -> None:
+        path = item.data(Qt.UserRole)
+        if path:
+            QDesktopServices.openUrl(QUrl.fromLocalFile(str(path)))


### PR DESCRIPTION
## Summary
- allow right-clicking INI entries to open them in the system editor
- show each config file's full path via tooltip
- add tests covering tooltip and open behavior

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ddf89a9a48323b52ada3caed6dae4