### PR TITLE
Add keyboard shortcuts for main menu actions

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -45,24 +45,28 @@ The main window consists of a search pane (left) and a details pane (right):
 
 ## 7. Resolving Duplicate Entries
 
-- Select **"Show Duplicates"** from the menu to open the conflict pane.
+- Select **"Show Duplicates"** from the menu or press <kbd>Ctrl+D</kbd> to open the conflict pane.
 - For each duplicate key, choose whether to comment out or delete lower priority entries.
 - Click **"Apply"** to update the staged configuration.
 
-## 8. Saving Changes
+## 8. Viewing Config Files
 
-1. Choose **"Save"** from the menu.
+- Select **"Config Files"** from the menu or press <kbd>Ctrl+F</kbd> to view and edit your project's configuration files.
+
+## 9. Saving Changes
+
+1. Choose **"Save"** from the menu or press <kbd>Ctrl+S</kbd>.
 2. The tool validates syntax and duplicate resolution.
 3. On success, new `.ini` files are written to your project’s `Config` folder.
 4. Originals are backed up to `Config/Backup/<timestamp>/`.
 
-## 9. Working with Presets
+## 10. Working with Presets
 
-- Select **"Presets"** from the menu to manage reusable configuration snippets.
+- Select **"Presets"** from the menu or press <kbd>Ctrl+P</kbd> to manage reusable configuration snippets.
 - **Import** adds settings from an existing preset file.
 - **Export Current** saves your merged configuration as a preset.
 
-## 10. Tips
+## 11. Tips
 
 - Window sizes and recent projects are stored in `~/.ue5_config_assistant/` so they persist across sessions.
 - You can rerun the tool at any time to edit or review your project’s configuration.

--- a/ue_configurator/ui/main_window.py
+++ b/ue_configurator/ui/main_window.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 
 from PySide6.QtWidgets import QSplitter, QMainWindow, QMessageBox
-from PySide6.QtGui import QAction, QDesktopServices
+from PySide6.QtGui import QAction, QDesktopServices, QKeySequence
 from PySide6.QtCore import QUrl
 
 from ..config_db import ConfigDB
@@ -45,12 +45,23 @@ class MainWindow(QMainWindow):
 
         # menu actions
         conflict_action = QAction("Show Duplicates", self)
+        conflict_action.setShortcut(QKeySequence("Ctrl+D"))
+        conflict_action.setToolTip("Show duplicate entries (Ctrl+D)")
         conflict_action.triggered.connect(self.show_conflicts)
+
         preset_action = QAction("Presets", self)
+        preset_action.setShortcut(QKeySequence("Ctrl+P"))
+        preset_action.setToolTip("Manage presets (Ctrl+P)")
         preset_action.triggered.connect(self.show_presets)
+
         files_action = QAction("Config Files", self)
+        files_action.setShortcut(QKeySequence("Ctrl+F"))
+        files_action.setToolTip("Browse config files (Ctrl+F)")
         files_action.triggered.connect(self.show_files)
+
         save_action = QAction("Save", self)
+        save_action.setShortcut(QKeySequence("Ctrl+S"))
+        save_action.setToolTip("Validate and save configuration (Ctrl+S)")
         save_action.triggered.connect(self.save_config)
         self.menuBar().addAction(conflict_action)
         self.menuBar().addAction(preset_action)


### PR DESCRIPTION
## Summary
- Add standard keyboard shortcuts and tooltips for Show Duplicates, Presets, Config Files, and Save actions
- Document shortcuts in the user guide, including new Config Files section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de38fdb4c8323af3dec85f7d0f1c0