### PR TITLE
Preserve in-memory edits during validation

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -56,7 +56,8 @@ The main window consists of a search pane (left) and a details pane (right):
 ## 9. Saving Changes
 
 1. Choose **"Save"** from the menu or press <kbd>Ctrl+S</kbd>.
-2. The tool validates syntax and duplicate resolution.
+2. The tool validates syntax and duplicate resolution using a temporary parser.
+   Unsaved in-memory edits remain intact even if validation fails.
 3. On success, new `.ini` files are written to your project’s `Config` folder.
 4. Originals are backed up to `Config/Backup/<timestamp>/`.
 

--- a/tests/test_config_db.py
+++ b/tests/test_config_db.py
@@ -111,5 +111,22 @@ def test_ignore_files(tmp_path: Path) -> None:
     assert "newkey" not in ini1.read_text().lower()
 
 
+def test_insert_persists_after_validate(tmp_path: Path) -> None:
+    cfg = tmp_path / "Config"
+    cfg.mkdir()
+    ini = cfg / "DefaultGame.ini"
+    write_ini(ini, "[Section]\nKey=1\n")
+
+    db = ConfigDB()
+    db.load(cfg)
+    db.insert_setting("Section", "NewKey", "2")
+    assert ("Section", "newkey") in db.entries()
+
+    db.validate()
+
+    assert ("Section", "newkey") in db.entries()
+    assert db.files[0].updater["Section"]["newkey"].value == "2"
+
+
 
 

--- a/ue_configurator/config_db.py
+++ b/ue_configurator/config_db.py
@@ -137,7 +137,8 @@ class ConfigDB:
         """Check for duplicates and basic syntax issues."""
         try:
             for ini in self._active_files():
-                ini.updater.read(str(ini.path))
+                tmp = ConfigUpdater(strict=False)
+                tmp.read(str(ini.path))
         except Exception as e:  # pragma: no cover - read should rarely fail
             return False, str(e)
         if self.find_duplicates():


### PR DESCRIPTION
## Summary
- Avoid clobbering in-memory ini edits by using a temporary `ConfigUpdater` in `ConfigDB.validate`
- Add regression test ensuring `insert_setting` changes survive a `validate` call
- Document that validation now preserves staged edits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de8219b2c8323aab7216792d79570