### PR TITLE
Support versioned cache files and rebuild command

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,5 +1,10 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from ue_configurator.indexer import index_headers, load_cache, detect_engine_from_uproject
+from ue_configurator.indexer import (
+    index_headers,
+    load_cache,
+    detect_engine_from_uproject,
+    detect_version_from_uproject,
+)
 from pathlib import Path
 
 def test_index_headers(tmp_path: Path):
@@ -17,8 +22,9 @@ def test_index_headers(tmp_path: Path):
 
 def test_load_cache(tmp_path: Path):
     cache = tmp_path / "cache.json"
-    cache.write_text('[{"name": "r.Test", "description": "Test", "default": "1", "category": "Cat", "range": "0-1"}]')
-    data = load_cache(cache)
+    versioned = cache.with_name("cache-5.4.json")
+    versioned.write_text('[{"name": "r.Test", "description": "Test", "default": "1", "category": "Cat", "range": "0-1"}]')
+    data = load_cache(cache, version="5.4")
     assert data[0]["name"] == "r.Test"
     assert data[0]["default"] == "1"
 
@@ -31,3 +37,10 @@ def test_detect_engine(tmp_path: Path):
     (proj / "Proj.uproject").write_text('{"EngineAssociation": "%s"}' % engine)
     found = detect_engine_from_uproject(proj)
     assert found == engine
+
+
+def test_detect_version(tmp_path: Path):
+    proj = tmp_path / "Proj"
+    proj.mkdir()
+    (proj / "Proj.uproject").write_text('{"EngineAssociation": "5.2"}')
+    assert detect_version_from_uproject(proj) == "5.2"

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -98,6 +98,6 @@ def test_build_cache_online(monkeypatch, tmp_path: Path):
         "ue_configurator.indexer.scrape_console_variables", fake_scrape
     )
     cache = tmp_path / "cache.json"
-    build_cache(cache)
-    data = json.loads(cache.read_text())
+    built = build_cache(cache)
+    data = json.loads(built.read_text())
     assert data[0]["name"] == "r.Online"

--- a/tests/test_search_pane.py
+++ b/tests/test_search_pane.py
@@ -23,3 +23,18 @@ def test_search_pane_uses_local_engine(tmp_path, monkeypatch):
     cache_file = tmp_path / "cache.json"
     pane = SearchPane(cache_file, project_dir, use_local_engine=True)
     assert captured["engine_root"] == engine_root
+
+
+def test_search_pane_appends_version(tmp_path, monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    project_dir = tmp_path / "Proj"
+    project_dir.mkdir()
+    (project_dir / "Proj.uproject").write_text(json.dumps({"EngineAssociation": "5.1"}))
+
+    def fake_build_cache(cache_file, engine_root=None, version="5.4", progress=None):
+        cache_file.write_text("[]")
+
+    monkeypatch.setattr("ue_configurator.ui.search_pane.build_cache", fake_build_cache)
+    cache_file = tmp_path / "cache.json"
+    pane = SearchPane(cache_file, project_dir)
+    assert pane.cache_file.name == "cache-5.1.json"


### PR DESCRIPTION
## Summary
- detect engine version from project metadata and store cache per version
- warn and handle outdated caches in indexer with versioned filenames
- add Rebuild Cache UI button and CLI flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de8fb288083238c5e29b6bd7f19b7